### PR TITLE
feat: 改进签到统计功能，支持自定义查询天数

### DIFF
--- a/nodeseek_sign.py
+++ b/nodeseek_sign.py
@@ -249,7 +249,10 @@ def get_signin_stats(ns_cookie, days=30):
     """查询前days天内的签到收益统计"""
     if not ns_cookie:
         return None, "无有效Cookie"
-        
+    
+    if days <= 0:
+        days = 1
+    
     headers = {
         'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
         'origin': "https://www.nodeseek.com",


### PR DESCRIPTION
当前的 `get_signin_stats` 函数只能查询当月的签到收益数据。在月初调用时，该功能几乎无法返回任何有意义的数据，用户无法有效评估近期的签到收益情况。

本次提交旨在解决这一局限性，使签到统计功能更加灵活和实用。

- 启用 `get_signin_stats` 函数的 `days` 参数，允许用户查询最近N天的签到数据。
- 使用最佳实践 `ZoneInfo` 处理时区问题。
- 增加对 `days` 参数的边界检查。
- 适当放宽分页查询的上限，以支持更长时间跨度的查询。